### PR TITLE
git-clone: Error out gracefully if URL cannot be fetched

### DIFF
--- a/clone.c
+++ b/clone.c
@@ -69,7 +69,10 @@ clone_http_get_head(char *url, char *sha)
 	long offset;
 
 	sprintf(fetchurl, "%s/info/refs?service=git-upload-pack", url);
-	web = fetchGetURL(fetchurl, NULL);
+	if ((web = fetchGetURL(fetchurl, NULL)) == NULL) {
+		fprintf(stderr, "Unable to clone repository: %s\n", url);
+		exit(128);
+	}
 	offset = 0;
 	smart_head.cap = 0;
 	response = NULL;


### PR DESCRIPTION
If fetchGetURL returns NULL then the fread call shortly thereafter will cause a segfault. Might as well gracefully error out as soon as we know we're unable to fetch the URL.