### PR TITLE
Misc cleanup

### DIFF
--- a/cat-file.c
+++ b/cat-file.c
@@ -152,7 +152,7 @@ cat_file_get_content_loose(char *sha_str, uint8_t flags)
 	int objectfd;
 	struct loosearg loosearg;
 
-	sprintf(objectpath, "%s/objects/%c%c/%s", dotgitpath, sha_str[0], sha_str[1], sha_str+2);
+	snprintf(objectpath, sizeof(objectpath), "%s/objects/%c%c/%s", dotgitpath, sha_str[0], sha_str[1], sha_str+2);
 	objectfd = open(objectpath, O_RDONLY);
 	if (objectfd == -1)
 		return 0;

--- a/clone.c
+++ b/clone.c
@@ -72,7 +72,8 @@ clone_http_get_head(char *url, struct smart_head *smart_head)
 	long offset;
 	int count;
 
-	sprintf(fetchurl, "%s/info/refs?service=git-upload-pack", url);
+	snprintf(fetchurl, sizeof(fetchurl), "%s/info/refs?service=git-upload-pack",
+	    url);
 	if ((web = fetchGetURL(fetchurl, NULL)) == NULL) {
 		fprintf(stderr, "Unable to clone repository: %s\n", url);
 		exit(128);
@@ -191,9 +192,9 @@ clone_http_build_want(char **content, int content_length, char *capabilities, co
 	/* size + want + space + SHA(40) + space + capabilities + newline */
 	len = 4 + 4 + 1 + 40 + 1 + strlen(capabilities) + 1;
 
-	sprintf(line, "%04xwant %s %s\n", len, sha, capabilities);
+	snprintf(line, sizeof(line), "%04xwant %s %s\n", len, sha, capabilities);
 	*content = realloc(*content, content_length + len + 1);
-	strncpy(*content+content_length, line, len+1);
+	strlcpy(*content+content_length, line, len+1);
 
 	return len;
 }
@@ -353,7 +354,7 @@ clone_http_get_sha(int packfd, char *url, struct smart_head *smart_head)
 	struct url *fetchurl;
 	FILE *packptr;
 
-	sprintf(git_upload_pack, "%s/git-upload-pack", url);
+	snprintf(git_upload_pack, sizeof(git_upload_pack), "%s/git-upload-pack", url);
 
 	fetchurl = fetchParseURL(git_upload_pack);
 	if (fetchurl == NULL) {

--- a/hash-object.c
+++ b/hash-object.c
@@ -110,9 +110,10 @@ hash_object_create_zlib(FILE *source, FILE *dest, unsigned char *header, unsigne
 	int have;
 	Bytef in[CHUNK];
 	Bytef out[CHUNK];
-	char filepath[PATH_MAX + NAME_MAX];
+	char filepath[PATH_MAX];
 
-	sprintf(filepath, "%s/objects/%c%c", dotgitpath, checksum[0], checksum[1]);
+	snprintf(filepath, sizeof(filepath), "%s/objects/%c%c", dotgitpath,
+	    checksum[0], checksum[1]);
 
 	strm.zalloc = Z_NULL;
 	strm.zfree = Z_NULL;
@@ -169,13 +170,13 @@ hash_object_create_file(FILE **objectfileptr, char *checksum)
 	char objectpath[PATH_MAX];
 
 	// First create the directory
-	sprintf(objectpath, "%s/objects/%c%c",
+	snprintf(objectpath, sizeof(objectpath), "%s/objects/%c%c",
 	    dotgitpath, checksum[0], checksum[1]);
 
 	mkdir(objectpath, 0755);
 
 	// Reusing objectpath variable
-	sprintf(objectpath, "%s/objects/%c%c/%s",
+	snprintf(objectpath, sizeof(objectpath), "%s/objects/%c%c/%s",
 	    dotgitpath, checksum[0], checksum[1], checksum+2);
 
 	*objectfileptr = fopen(objectpath, "w");

--- a/lib/common.c
+++ b/lib/common.c
@@ -64,7 +64,7 @@ git_repository_path()
 	/* XXX Is there a better way to do this? */
 
 	while (strncmp(d, "/\0", 2) != 0) {
-		sprintf(path, "%s/.git", d);
+		snprintf(path, sizeof(path), "%s/.git", d);
 		s = stat(path, &sb);
 		if (s == -1) {
 			d = dirname(d);
@@ -76,7 +76,7 @@ git_repository_path()
 		}
 		else if (s == 0) {
 			ret = 0;
-			strncpy(dotgitpath, path, strlen(path));
+			strlcpy(dotgitpath, path, sizeof(dotgitpath));
 			break;
 		}
 	};

--- a/lib/common.c
+++ b/lib/common.c
@@ -44,14 +44,14 @@
 	If errors, returns -1
 */
 
-char dotgitpath[PATH_MAX + NAME_MAX];
+char dotgitpath[PATH_MAX];
 
 int
 git_repository_path()
 {
 	char *d = NULL;
 	int s;
-	char path[PATH_MAX + 5];
+	char path[PATH_MAX];
 	struct stat sb;
 	int ret = 1;
 

--- a/lib/common.h
+++ b/lib/common.h
@@ -32,7 +32,7 @@
 #define nitems(x)	(sizeof((x)) / sizeof((x)[0]))
 #define BIT(nr)		(1 << (nr))
 
-extern char		dotgitpath[PATH_MAX + NAME_MAX];
+extern char		dotgitpath[PATH_MAX];
 int			git_repository_path();
 
 #endif

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -51,6 +51,7 @@ config_parser()
 	struct section *current_section = sections;
 	struct section *new_section;
 	char ini_file[PATH_MAX];
+	int sz;
 
 	char tmp[1000];
 	char tmpvar[1000];
@@ -82,18 +83,16 @@ config_parser()
 			}
 			else if (strncmp(tmp, "remote", 6) == 0) {
 				new_section->type = REMOTE;
-				tmpval = malloc(pmatch[2].rm_eo - pmatch[2].rm_so);
-				strncpy(tmpval, line + pmatch[2].rm_so,
-				    pmatch[2].rm_eo - pmatch[2].rm_so);
-				new_section->repo_name = tmpval;
+				sz = pmatch[2].rm_eo - pmatch[2].rm_so;
+				new_section->repo_name = malloc(sz + 1);
+				strlcpy(new_section->repo_name, line + pmatch[2].rm_so,
+				   sz + 1);
 			}
 
 			new_section->next = NULL;
 			if (sections == NULL) {
-				sections = new_section;
-				current_section = sections;
-			}
-			else {
+				current_section = sections = new_section;
+			} else {
 				current_section->next = new_section;
 				current_section = new_section;
 			}

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -61,7 +61,7 @@ config_parser()
 
 	ini_init_regex();
 
-	sprintf(ini_file, "%s/config", dotgitpath);
+	snprintf(ini_file, sizeof(ini_file), "%s/config", dotgitpath);
 	fp = fopen(ini_file, "r");
 	if (!fp) {
 		printf("Unable to open file: %s\n", ini_file);

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -152,7 +152,8 @@ config_parser()
 				current_section->url = tmpval;
 			else if (strncmp("fetch", tmpvar, 5) == 0)
 				current_section->fetch = tmpval;
-
+			else
+				free(tmpval);
 			continue;
 		}
 	}

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -68,7 +68,7 @@ config_parser()
 		return (-1);
 	}
 
-	while (fgets(line, 1000, fp) != NULL) {
+	while (fgets(line, sizeof(line), fp) != NULL) {
 		line[strlen(line)-1] = '\0'; // chomp()
 
 		if (regexec(&re_core_header, line, 2, pmatch, 0) != REG_NOMATCH ||

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -32,6 +32,8 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <errno.h>
+
+#include "common.h"
 #include "ini.h"
 
 static regex_t re_core_header;
@@ -39,8 +41,6 @@ static regex_t re_remote_header;
 static regex_t re_variable;
 
 struct section *sections = NULL;
-
-char dotgitpath[PATH_MAX + NAME_MAX];
 
 int
 config_parser()

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -50,7 +50,7 @@ config_parser()
 	regmatch_t pmatch[10];
 	struct section *current_section = sections;
 	struct section *new_section;
-	char ini_file[PATH_MAX + NAME_MAX];
+	char ini_file[PATH_MAX];
 
 	char tmp[1000];
 	char tmpvar[1000];

--- a/lib/pack.c
+++ b/lib/pack.c
@@ -198,7 +198,7 @@ pack_get_object_meta(int packfd, int offset, struct packfileinfo *packfileinfo,
 		case OBJ_OFS_DELTA:
 			SHA1_Init(&index_generate_arg.shactx);
 			pack_delta_content(packfd, &objectinfo, packctx);
-			hdrlen = sprintf(hdr, "%s %lu",
+			hdrlen = snprintf(hdr, sizeof(hdr), "%s %lu",
 			    object_name[objectinfo.ftype],
 			    objectinfo.isize) + 1;
 			SHA1_Update(&index_generate_arg.shactx, hdr, hdrlen);
@@ -223,7 +223,7 @@ pack_get_object_meta(int packfd, int offset, struct packfileinfo *packfileinfo,
 			index_generate_arg.bytes = 0;
 			SHA1_Init(&index_generate_arg.shactx);
 
-			hdrlen = sprintf(hdr, "%s %lu",
+			hdrlen = snprintf(hdr, sizeof(hdr), "%s %lu",
 			    object_name[objectinfo.ftype],
 			    objectinfo.psize) + 1;
 			SHA1_Update(&index_generate_arg.shactx, hdr, hdrlen);

--- a/lib/pack.c
+++ b/lib/pack.c
@@ -428,7 +428,7 @@ pack_get_packfile_offset(char *sha_str, char *filename)
 	for (i=0;i<20;i++)
 		sscanf(sha_str+i*2, "%2hhx", &sha_bin[i]);
 
-	sprintf(packdir, "%s/objects/pack", dotgitpath);
+	snprintf(packdir, sizeof(packdir), "%s/objects/pack", dotgitpath);
 	d = opendir(packdir);
 
 	/* Find hash in idx file or die */
@@ -437,7 +437,9 @@ pack_get_packfile_offset(char *sha_str, char *filename)
 			file_ext = strrchr(dir->d_name, '.');
 			if (!file_ext || strncmp(file_ext, ".idx", 4))
 				continue;
-			sprintf(filename, "%s/objects/pack/%s", dotgitpath, dir->d_name);
+			/* XXX This is wrong; we need to know the size of the buffer */
+			snprintf(filename, PATH_MAX, "%s/objects/pack/%s", dotgitpath,
+			    dir->d_name);
 
 			packfd = open(filename, O_RDONLY);
 			fstat(packfd, &sb);

--- a/lib/pack.c
+++ b/lib/pack.c
@@ -570,6 +570,7 @@ pack_object_header(int packfd, int offset, struct objectinfo *objectinfo,
 	objectinfo->offset = offset;
 	objectinfo->used = 1;
 
+	c = 0;
 	buf_read(packfd, &c, 1, read_sha_update, packctx);
 
 	objectinfo->crc = crc32(objectinfo->crc, &c, 1);

--- a/log.c
+++ b/log.c
@@ -71,7 +71,7 @@ log_print_commit_headers(struct logarg *logarg)
 	char *tofree;
 	char *datestr;
 	char author[255];
-	long t;
+	time_t t;
 
 	tofree = tmp = strdup(logarg->headers);
 	printf("\e[0;33mcommit %s\e[0m\n", logarg->sha);
@@ -139,7 +139,7 @@ log_get_start_sha(struct logarg *logarg)
 	char ref[PATH_MAX];
 	int l;
 
-	sprintf(headfile, "%s/HEAD", dotgitpath);
+	snprintf(headfile, sizeof(headfile), "%s/HEAD", dotgitpath);
 	headfd = open(headfile, O_RDONLY);
 	if (headfd == -1) {
 		fprintf(stderr, "Error, no HEAD file found. This may not be a git directory\n");
@@ -152,7 +152,7 @@ log_get_start_sha(struct logarg *logarg)
 		l = read(headfd, ref, PATH_MAX) - 1;
 		if (ref[l] == '\n')
 			ref[l] = '\0';
-		sprintf(refpath, "%s/%s", dotgitpath, ref);
+		snprintf(refpath, sizeof(refpath), "%s/%s", dotgitpath, ref);
 	}
 	else {
 		fprintf(stderr, "Currently not supporting the raw hash in HEAD\n");
@@ -175,7 +175,7 @@ log_get_loose_object(struct logarg *logarg)
 	int objectfd;
 	char objectpath[PATH_MAX];
 
-	sprintf(objectpath, "%s/objects/%c%c/%s",
+	snprintf(objectpath, sizeof(objectpath), "%s/objects/%c%c/%s",
 	    dotgitpath, logarg->sha[0], logarg->sha[1],
 	    logarg->sha+2);
 	objectfd = open(objectpath, O_RDONLY);

--- a/ogit.h
+++ b/ogit.h
@@ -35,8 +35,6 @@ struct cmd {
 	int		(*c_func)(int argc, char *argv[]);
 };
 
-extern char dotgitpath[PATH_MAX + NAME_MAX];
-
 extern int cmd_count;
 
 extern int log_main();

--- a/remote.c
+++ b/remote.c
@@ -89,7 +89,7 @@ remote_remove(int argc, char *argv[], uint8_t flags)
 
 	cur_section = sections;
 
-	sprintf(tmpconfig, "%s/.config.XXXXXX", dotgitpath);
+	snprintf(tmpconfig, sizeof(tmpconfig), "%s/.config.XXXXXX", dotgitpath);
 	fd = mkstemp(tmpconfig);
 	if (fd == -1) {
 		fprintf(stderr, "Unable to open temporary file: %s\n", tmpconfig);

--- a/update-index.c
+++ b/update-index.c
@@ -59,8 +59,8 @@ int
 update_index_open_index(FILE **indexptr)
 {
 	char indexpath[PATH_MAX];
-	sprintf(indexpath, "%s/index", dotgitpath);
 
+	snprintf(indexpath, sizeof(indexpath), "%s/index", dotgitpath);
 	printf("File: %s\n", indexpath);
 
 	*indexptr = fopen(indexpath, "rw");


### PR DESCRIPTION
Highlights:
- Removing duplicate definitions
- Favoring strlcpy over strncpy
- Favoring snprintf over sprintf
- Proper sizing of vars holding paths