### PR TITLE
Improve portability to OpenBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 # $FreeBSD$
 
+.PATH: ${.CURDIR}/lib
+
 MAN=
-CFLAGS=	-Wall -lmd -lz -lfetch
+CFLAGS+= -Wall
+LDFLAGS= -lmd -lz -lfetch
 
 PROG=	ogit
 
-SRCS=	ogit.c lib/ini.c lib/index.c lib/common.c lib/pack.c remote.c init.c \
-	lib/zlib-handler.c lib/buffering.c lib/loose.c \
+SRCS=	ogit.c ini.c index.c common.c pack.c remote.c init.c \
+	zlib-handler.c buffering.c loose.c \
 	hash-object.c update-index.c cat-file.c log.c clone.c index-pack.c
 
 CLEANFILES+=	${PROG}.core

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ LDFLAGS= -lmd -lz -lfetch
 
 PROG=	ogit
 
-SRCS=	ogit.c ini.c index.c common.c pack.c remote.c init.c \
-	zlib-handler.c buffering.c loose.c \
-	hash-object.c update-index.c cat-file.c log.c clone.c index-pack.c
+SRCS=	cat-file.c clone.c hash-object.c index-pack.c init.c log.c \
+	ogit.c remote.c update-index.c
+
+SRCS+=	buffering.c common.c index.c ini.c loose.c pack.c zlib-handler.c
 
 CLEANFILES+=	${PROG}.core
 

--- a/clone.c
+++ b/clone.c
@@ -40,7 +40,6 @@
 #include <fcntl.h>
 #include <fetch.h>
 #include <errno.h>
-#include <sha.h>
 #include "lib/zlib-handler.h"
 #include "lib/loose.h"
 #include "lib/common.h"

--- a/hash-object.c
+++ b/hash-object.c
@@ -35,7 +35,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sha.h>
 #include <zlib.h>
 #include "lib/zlib-handler.h"
 #include "lib/common.h"

--- a/lib/buffering.c
+++ b/lib/buffering.c
@@ -27,8 +27,8 @@
 
 #include <stdlib.h>
 #include <zlib.h>
-#include <sha.h>
 #include "buffering.h"
+#include "common.h"
 
 ssize_t
 buf_read(int fd, void *buf, size_t count, read_handler read_handler, void *arg)

--- a/lib/common.h
+++ b/lib/common.h
@@ -30,8 +30,24 @@
 #include <limits.h>
 #include <stdint.h>
 
+/* Portability */
+#if defined(__FreeBSD__)
+#include <sha.h>
+#elif defined(__OpenBSD__)
+#include <sha1.h>
+
+#define SHA1_End(x, y)	SHA1End(x, y)
+#define SHA1_Final(x, y) SHA1Final(x, y)
+#define SHA1_Init(x)	SHA1Init(x)
+#define SHA1_Update(x, y, z) SHA1Update(x, y, z)
+#endif
+
 #define HASH_SIZE	40
+
+#ifndef nitems
 #define nitems(x)	(sizeof((x)) / sizeof((x)[0]))
+#endif
+
 #define BIT(nr)		(1 << (nr))
 
 typedef void		tree_handler(char *, uint8_t, char *, char *, void *);

--- a/lib/common.h
+++ b/lib/common.h
@@ -40,6 +40,8 @@
 #define SHA1_Final(x, y) SHA1Final(x, y)
 #define SHA1_Init(x)	SHA1Init(x)
 #define SHA1_Update(x, y, z) SHA1Update(x, y, z)
+#else
+#error "Unsure what to do for inclusion of sha1 bits in this environment"
 #endif
 
 #define HASH_SIZE	40

--- a/lib/pack.c
+++ b/lib/pack.c
@@ -37,7 +37,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <zlib.h>
-#include <sha.h>
 #include "buffering.h"
 #include "zlib-handler.h"
 #include "pack.h"

--- a/lib/pack.h
+++ b/lib/pack.h
@@ -30,7 +30,7 @@
 
 #include <sys/types.h>
 #include <stdint.h>
-#include <sha.h>
+#include "common.h"
 
 
 /*

--- a/lib/zlib-handler.c
+++ b/lib/zlib-handler.c
@@ -31,7 +31,7 @@
 #include <zlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <sha.h>
+#include "common.h"
 #include "zlib-handler.h"
 
 unsigned char *

--- a/update-index.c
+++ b/update-index.c
@@ -36,7 +36,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sha.h>
 #include "lib/common.h"
 #include "lib/index.h"
 #include "lib/ini.h"


### PR DESCRIPTION
This is probably the best we can do for a single, unified source between FreeBSD and OpenBSD. OpenBSD still needs some tweaks (no -lmd on OpenBSD, needs -I/usr/local/include and -L/usr/local/lib in the right places, needs %lld instead of %ld when printing time_t) but this keeps things very close together now.